### PR TITLE
fix(service): persist CODEX_BIN across background service launches

### DIFF
--- a/src/service/launchd.ts
+++ b/src/service/launchd.ts
@@ -66,7 +66,9 @@ export function buildPlist(): string {
   <dict>
     <key>PATH</key>
     <string>${escapeXml(pathEnv)}</string>
-  </dict>
+${process.env.CODEX_BIN ? `    <key>CODEX_BIN</key>
+    <string>${escapeXml(process.env.CODEX_BIN)}</string>
+` : ''}  </dict>
 </dict>
 </plist>
 `;

--- a/src/service/systemd.ts
+++ b/src/service/systemd.ts
@@ -42,6 +42,7 @@ export function buildUnit(): string {
   const nodePath = process.execPath;
   const cliBinPath = resolveCliBinPath();
   const pathEnv = process.env.PATH ?? '';
+  const codexBinEnv = process.env.CODEX_BIN ? `Environment="CODEX_BIN=${esc(process.env.CODEX_BIN)}"\n` : '';
   return `[Unit]
 Description=feishu-codex-bridge bot
 After=network-online.target
@@ -55,6 +56,7 @@ RestartSec=5
 StandardOutput=append:${serviceStdoutPath()}
 StandardError=append:${serviceStderrPath()}
 Environment="PATH=${esc(pathEnv)}"
+${codexBinEnv}
 
 [Install]
 WantedBy=default.target

--- a/src/service/win-startup.ts
+++ b/src/service/win-startup.ts
@@ -62,6 +62,7 @@ export function buildLauncherCmd(): string {
   return [
     '@echo off',
     `set "PATH=${process.env.PATH ?? ''}"`,
+    ...(process.env.CODEX_BIN ? [`set "CODEX_BIN=${process.env.CODEX_BIN}"`] : []),
     `set "${SERVICE_ENV_FLAG}=1"`,
     `"${process.execPath}" "${resolveCliBinPath()}" run >> "${serviceStdoutPath()}" 2>> "${serviceStderrPath()}"`,
     '',

--- a/test/service-definitions.test.ts
+++ b/test/service-definitions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { buildPlist } from '../src/service/launchd';
 import { buildUnit, SYSTEMD_UNIT_NAME } from '../src/service/systemd';
 import { buildLauncherCmd, buildLauncherVbs } from '../src/service/win-startup';
 
@@ -28,6 +29,22 @@ describe('systemd unit (buildUnit)', () => {
   it('unit name is a .service', () => {
     expect(SYSTEMD_UNIT_NAME).toMatch(/\.service$/);
   });
+
+  it('preserves an explicit CODEX_BIN override for the background service', () => {
+    withCodexBin('/opt/codex/bin/codex', () => {
+      expect(buildUnit()).toContain('Environment="CODEX_BIN=/opt/codex/bin/codex"');
+    });
+  });
+});
+
+describe('launchd plist (buildPlist)', () => {
+  it('preserves an explicit CODEX_BIN override for the background service', () => {
+    withCodexBin('/Applications/Codex & Friends.app/Contents/Resources/codex', () => {
+      const plist = buildPlist();
+      expect(plist).toContain('<key>CODEX_BIN</key>');
+      expect(plist).toContain('/Applications/Codex &amp; Friends.app/Contents/Resources/codex');
+    });
+  });
 });
 
 describe('Windows hidden launcher (.cmd)', () => {
@@ -45,6 +62,12 @@ describe('Windows hidden launcher (.cmd)', () => {
     expect(cmd).toContain('>> "');
     expect(cmd).toContain('2>> "');
   });
+
+  it('preserves an explicit CODEX_BIN override for the background service', () => {
+    withCodexBin('C:\\Tools\\codex.exe', () => {
+      expect(buildLauncherCmd()).toContain('set "CODEX_BIN=C:\\Tools\\codex.exe"');
+    });
+  });
 });
 
 describe('Windows hidden launcher (.vbs)', () => {
@@ -55,3 +78,14 @@ describe('Windows hidden launcher (.vbs)', () => {
     expect(vbs).toMatch(/sh\.Run "cmd \/c "".+\.cmd""", 0, False/);
   });
 });
+
+function withCodexBin(value: string, fn: () => void): void {
+  const prev = process.env.CODEX_BIN;
+  process.env.CODEX_BIN = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.CODEX_BIN;
+    else process.env.CODEX_BIN = prev;
+  }
+}


### PR DESCRIPTION
## 背景

Bridge 通過 Codex App Server 的 `model/list` 動態獲取可用模型，因此無需在項目內硬編碼 GPT-5.6。當新版 Codex CLI 僅通過 `CODEX_BIN` 指定時，前台運行能正常發現 GPT-5.6，但安裝為後台服務後可能重新使用 `PATH` 中的舊版 Codex。

這會造成同一台機器上的前台與後台行為不一致：前台可以選擇 GPT-5.6，服務重啟或重新登錄後，模型列表中卻不再出現 GPT-5.6，以及新版 CLI 提供的 `max` / `ultra` 推理強度。

## 根因

`resolveCodexBin()` 已將 `CODEX_BIN` 作為最高優先級的顯式覆蓋，但三個後台服務適配器生成啟動配置時只保留了 `PATH`，沒有跨越服務邊界傳遞 `CODEX_BIN`：

```text
當前行為：shell CODEX_BIN -> install/start -> service 僅保存 PATH -> daemon 回退到舊版 codex
修復後：  shell CODEX_BIN -> install/start -> service 保存 CODEX_BIN -> daemon 使用指定 codex
```

## 修改內容

| 平台 | 服務適配器 | 修改 |
| --- | --- | --- |
| macOS | launchd | 在 `EnvironmentVariables` 中寫入經 XML 轉義的 `CODEX_BIN` |
| Linux / WSL | systemd user unit | 增加經轉義的 `Environment="CODEX_BIN=..."` |
| Windows | Startup `.cmd` | 增加 `set "CODEX_BIN=..."` |

同時在 `test/service-definitions.test.ts` 補充三個平台的專項測試，覆蓋路徑中的空格、反斜線與 XML 特殊字符。

## 行為與兼容性

- 僅在調用安裝或啟動命令時顯式設置了 `CODEX_BIN` 才會寫入服務配置。
- 未設置 `CODEX_BIN` 時，生成結果及現有二進制查找順序保持不變。
- 不硬編碼任何 GPT-5.6 模型 ID，也不修改 `model/list`、模型選擇卡或默認模型邏輯。
- 不改變 `CODEX_BIN` > `PATH` > 私有安裝 > App Bundle 的既有解析優先級。

## 用戶影響

依賴自定義或較新版 Codex 二進制的用戶，在服務重啟、系統重新登錄或後台自動拉起後，仍會使用安裝服務時明確指定的同一個 Codex。模型列表與推理強度因此和前台運行保持一致。

## 驗證

```text
npx vitest run test/service-definitions.test.ts  # 9 tests passed
npm run typecheck                                # passed
npm run build                                    # passed
```
